### PR TITLE
Fix for Android platform + project Build fix

### DIFF
--- a/src/Shared.SocketMeister/SocketServer.cs
+++ b/src/Shared.SocketMeister/SocketServer.cs
@@ -80,7 +80,8 @@ namespace SocketMeister
         /// </summary>
         /// <param name="Port">Port that this socket server will listen on</param>
         /// <param name="CompressSentData">Enable compression on message data</param>
-        public SocketServer(int Port, bool CompressSentData)
+        /// <param name="DontLinger">Set socket don't linger option</param>
+        public SocketServer(int Port, bool CompressSentData, bool DontLinger = true)
         {
             _compressSentData = CompressSentData;
 
@@ -97,7 +98,8 @@ namespace SocketMeister
 
             //  WARNING - DO NOT USE SocketOptionName.ReceiveTimeout OR SocketOptionName.SendTimeout. TRIED THIS AND IT COMPLETELY BROKE THIS FOR BIG DATA TRANSFERS
             _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
-            _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontLinger, 0);
+            if(DontLinger)
+                _listener.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontLinger, 0);
 
             //  REGISTER FOR EVENTS
             _connectedClients.ClientDisconnected += ConnectedClients_ClientDisconnected;
@@ -110,7 +112,6 @@ namespace SocketMeister
                 IsBackground = true
             };
         }
-
 
         internal Clients ConnectedClients => _connectedClients;
 

--- a/src/SocketMeister (.NET Standard 2.0)/SocketMeister (.NET Standard 2.0).csproj
+++ b/src/SocketMeister (.NET Standard 2.0)/SocketMeister (.NET Standard 2.0).csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageIconUrl></PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <DocumentationFile>C:\Users\sfell\Source\Repos\SeanFellowes\SocketMeister\src\SocketMeister (.NET Standard 2.0)\SocketMeister.xml</DocumentationFile>
+    <DocumentationFile>SocketMeister.xml</DocumentationFile>
     <PackageIcon>icon_128.png</PackageIcon>
     <SelfContained>true</SelfContained>
     <Version>4.0.6</Version>
@@ -26,6 +26,7 @@
     <PackageReadmeFile>NuGetDocumentation.md</PackageReadmeFile>
     <Title>SocketMeister</Title>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>False</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net35|AnyCPU'">


### PR DESCRIPTION
- Removed build `Documentation File` option from proj props as it has inexistent path leading to failed  build
- Added new optional param to SocketServer constructor to exclude `DontLinger` socket option as it fails on Android

Successfully tested .netstandard20 on Android. It work now.